### PR TITLE
[codex] add contributor guide and note description parsing

### DIFF
--- a/.codex/skills/publish-note-blog/SKILL.md
+++ b/.codex/skills/publish-note-blog/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: publish-note-blog
+description: Publish Markdown as a blog post through the all-in-github Note issue workflow. Use when the user wants Codex to create or update a GitHub issue comment that contains hidden HTML metadata comments for title, description, and tags, so the repository's build-note GitHub Action generates an Astro blog post from a Note-labeled issue comment.
+---
+
+# Publish Note Blog
+
+## Overview
+
+Publish posts by creating or editing comments on GitHub issues labeled `Note`. The repository workflow runs only when the comment author is the repository owner, so prefer the locally authenticated `gh` account.
+
+This skill supports the Note-comment flow only. Do not use it for the separate `Blog` + `Publishing` issue flow.
+
+## Workflow
+
+1. Collect the post fields: title, description, tags, body, and the intended category labels.
+2. Use a Note issue as the category container. If the user provides an issue number, use it. Otherwise find an open issue with `Note` plus all requested category labels; if none exists, create one with `--issue-title`.
+3. Format the comment with hidden metadata before the Markdown body:
+
+   ```md
+   <!-- title:  Windows 常用软件  -->
+   <!-- tags:  Windows, 开发工具  -->
+   <!-- description:  Windows 常用工具集合  -->
+
+   ## 正文
+   ```
+
+4. Post a new comment or update an existing comment ID. Creating or editing the comment triggers `build-note`.
+5. If requested, watch the latest `build-note.yml` run.
+
+## Script
+
+Use `scripts/publish_note.py` for deterministic publishing:
+
+```bash
+python3 ~/.codex/skills/publish-note-blog/scripts/publish_note.py \
+  --repo byodian/all-in-github \
+  --issue 27 \
+  --title "Windows 常用软件" \
+  --description "Windows 常用工具集合" \
+  --tags "Windows,开发工具" \
+  --body-file ./post.md
+```
+
+Useful options:
+
+- `--category-label LABEL`: add one or more category labels to the issue; repeat for multiple labels.
+- `--issue-title TITLE`: create a Note issue with this title when no matching issue is found.
+- `--comment-id ID`: update an existing comment instead of creating a new one.
+- `--body-file -`: read the Markdown body from stdin.
+- `--dry-run`: print the exact comment body without changing GitHub.
+- `--watch`: wait for the newest `build-note.yml` workflow run.
+
+## Guardrails
+
+- Confirm `gh auth status` uses the repository owner before publishing; otherwise the workflow condition will skip the run.
+- Do not include the metadata HTML comments in the visible body; the action strips them before writing Markdown.
+- Keep tags comma-separated in the metadata comment. Category labels come from the issue labels, not from the `tags` metadata.
+- Do not publish secrets or private tokens in the Markdown body.

--- a/.codex/skills/publish-note-blog/agents/openai.yaml
+++ b/.codex/skills/publish-note-blog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Publish Note Blog"
+  short_description: "Publish Note issue comments to the blog"
+  default_prompt: "Use $publish-note-blog to publish this Markdown as a Note blog post."

--- a/.codex/skills/publish-note-blog/scripts/publish_note.py
+++ b/.codex/skills/publish-note-blog/scripts/publish_note.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Publish a Note blog post by creating or updating a GitHub issue comment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def run_gh(args: list[str], *, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise SystemExit(f"gh {' '.join(args)} failed: {message}")
+    return result.stdout.strip()
+
+
+def split_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def read_body(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read().strip()
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read().strip()
+
+
+def format_comment(title: str, description: str, tags: list[str], body: str) -> str:
+    return "\n".join(
+        [
+            f"<!-- title:  {title.strip()}  -->",
+            f"<!-- tags:  {', '.join(tags)}  -->",
+            f"<!-- description:  {description.strip()}  -->",
+            "",
+            body.strip(),
+            "",
+        ]
+    )
+
+
+def issue_labels(issue: dict[str, Any]) -> set[str]:
+    return {label["name"] for label in issue.get("labels", [])}
+
+
+def find_issue(repo: str, labels: list[str]) -> int | None:
+    payload = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "Note",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,labels",
+        ]
+    )
+    issues = json.loads(payload or "[]")
+    required = set(labels)
+    matches = [
+        issue
+        for issue in issues
+        if required.issubset(issue_labels(issue))
+    ]
+    if len(matches) > 1:
+        summary = ", ".join(f"#{issue['number']} {issue['title']}" for issue in matches)
+        raise SystemExit(f"multiple matching Note issues found: {summary}; pass --issue")
+    if not matches:
+        return None
+    return int(matches[0]["number"])
+
+
+def get_issue(repo: str, issue_number: int) -> dict[str, Any]:
+    payload = run_gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,labels,state",
+        ]
+    )
+    issue = json.loads(payload)
+    labels = issue_labels(issue)
+    if "Note" not in labels:
+        raise SystemExit(f"issue #{issue_number} is missing the Note label")
+    if issue.get("state") != "OPEN":
+        raise SystemExit(f"issue #{issue_number} is not open")
+    return issue
+
+
+def create_issue(repo: str, title: str, labels: list[str]) -> int:
+    args = [
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        title,
+        "--body",
+        "Container issue for Note blog comments.",
+        "--label",
+        "Note",
+    ]
+    for label in labels:
+        args.extend(["--label", label])
+    output = run_gh(args)
+    issue_url = output.splitlines()[-1]
+    return int(issue_url.rstrip("/").split("/")[-1])
+
+
+def ensure_labels(repo: str, issue_number: int, labels: list[str]) -> None:
+    issue = get_issue(repo, issue_number)
+    missing = [label for label in labels if label not in issue_labels(issue)]
+    if missing:
+        run_gh(
+            [
+                "issue",
+                "edit",
+                str(issue_number),
+                "--repo",
+                repo,
+                "--add-label",
+                ",".join(missing),
+            ]
+        )
+
+
+def post_comment(repo: str, issue_number: int, body: str) -> str:
+    endpoint = f"repos/{repo}/issues/{issue_number}/comments"
+    payload = json.dumps({"body": body}, ensure_ascii=False)
+    response = run_gh(["api", endpoint, "--method", "POST", "--input", "-"], input_text=payload)
+    return json.loads(response)["html_url"]
+
+
+def update_comment(repo: str, comment_id: str, body: str) -> str:
+    endpoint = f"repos/{repo}/issues/comments/{comment_id}"
+    payload = json.dumps({"body": body}, ensure_ascii=False)
+    response = run_gh(["api", endpoint, "--method", "PATCH", "--input", "-"], input_text=payload)
+    return json.loads(response)["html_url"]
+
+
+def watch_latest_build_note(repo: str) -> None:
+    time.sleep(8)
+    payload = run_gh(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            "build-note.yml",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId,status,conclusion,displayTitle,createdAt",
+        ]
+    )
+    runs = json.loads(payload or "[]")
+    if not runs:
+        raise SystemExit("no build-note.yml workflow run found")
+    run_id = str(runs[0]["databaseId"])
+    print(f"Watching build-note.yml run {run_id}")
+    run_gh(["run", "watch", run_id, "--repo", repo, "--exit-status"])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="byodian/all-in-github")
+    parser.add_argument("--issue", type=int)
+    parser.add_argument("--issue-title")
+    parser.add_argument("--category-label", action="append", default=[])
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--description", required=True)
+    parser.add_argument("--tags", required=True, help="Comma-separated post tags")
+    parser.add_argument("--body-file", required=True, help="Markdown file path, or - for stdin")
+    parser.add_argument("--comment-id", help="Existing GitHub issue comment ID to update")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--watch", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    category_labels = [label.strip() for label in args.category_label if label.strip()]
+    tags = split_csv(args.tags)
+    if not tags:
+        raise SystemExit("--tags must include at least one tag")
+
+    body = read_body(args.body_file)
+    if not body:
+        raise SystemExit("--body-file must not be empty")
+
+    comment_body = format_comment(args.title, args.description, tags, body)
+    if args.dry_run:
+        print(comment_body, end="")
+        return
+
+    issue_number = args.issue
+    if issue_number is None:
+        issue_number = find_issue(args.repo, category_labels)
+    if issue_number is None:
+        if not args.issue_title:
+            raise SystemExit("no matching Note issue found; pass --issue or --issue-title")
+        issue_number = create_issue(args.repo, args.issue_title, category_labels)
+    else:
+        ensure_labels(args.repo, issue_number, category_labels)
+
+    if args.comment_id:
+        url = update_comment(args.repo, args.comment_id, comment_body)
+        print(f"Updated comment: {url}")
+    else:
+        url = post_comment(args.repo, issue_number, comment_body)
+        print(f"Created comment: {url}")
+
+    if args.watch:
+        watch_latest_build_note(args.repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `actions/`: TypeScript scripts that read GitHub Issues/comments and generate Markdown content.
+- `actions/src/config.ts`: repository, timezone, labels, and content path settings.
+- `blog/`: AstroPaper-based blog subtree with pages, layouts, components, styles, and content.
+- `blog/src/content/blog/`: generated and manually maintained Markdown posts.
+- `blog/public/`: static assets served by the blog.
+- `.github/workflows/`: note generation, blog publishing, and GitHub Pages deployment.
+
+## Build, Test, and Development Commands
+
+- `npm run install:all`: install dependencies for both `actions/` and `blog/`.
+- `npm run build:actions`: compile the GitHub automation TypeScript.
+- `npm run build:blog`: run `astro check`, build the site, and generate Pagefind search assets.
+- `npm run build:all`: build both project areas.
+- `npm run lint:all`: run ESLint for both areas; current scripts may apply fixes.
+- `npm run dev:blog`: start the Astro development server.
+
+## Coding Style & Naming Conventions
+
+`actions/` uses TypeScript with single quotes and no semicolons. `blog/` follows ESLint, Prettier, Astro, and Tailwind config; use `pnpm --prefix blog format`. Avoid `console` in blog code because ESLint rejects it.
+
+Keep simple one-off predicates, guards, and sorting expressions inline. Add helpers only when they are reused or hide meaningful domain complexity.
+
+Name Astro components in PascalCase, for example `Header.astro`. Keep utility modules in camelCase, for example `getSortedPosts.ts`. Blog files may include dates and Chinese titles; preserve generated names unless changing the generator.
+
+## Testing Guidelines
+
+There is no separate unit test suite. Treat builds as required verification:
+
+- Run `npm run build:actions` after changing `actions/src`.
+- Run `npm run build:blog` after changing Astro pages, components, styles, config, or content.
+- Run `npm run lint:all` before submitting broad code changes.
+
+For content-only Markdown edits, verify frontmatter and run the blog build when practical.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use concise messages such as `docs: ...`, `docs(categories: Note, tags: ...): update ...`, and `update makeNote action script`. Prefer imperative, scoped messages: `fix(actions): handle missing issue labels` or `docs: update blog setup notes`.
+
+Pull requests should include a summary, affected area (`actions`, `blog`, workflows, or content), verification commands, and screenshots for visible blog UI changes. Link related issues when changing Issue publishing behavior.
+
+## Security & Configuration Tips
+
+Do not commit personal access tokens or generated secrets. Repository values live in `actions/src/config.ts` and `blog/src/config.ts`; update owner, repo, site URL, and base path together when forking.

--- a/actions/src/makeNote.ts
+++ b/actions/src/makeNote.ts
@@ -11,7 +11,7 @@ import {
   OWNER,
   REPO,
 } from './config'
-import { extractTagsFromComment, extractTitleFromComment, formatDate, hasIntersection, stripHtmlComments } from './utils'
+import { extractDescriptionFromComment, extractTagsFromComment, extractTitleFromComment, formatDate, hasIntersection, stripHtmlComments } from './utils'
 const { GITHUB_TOKEN, ISSUE_NUMBER, COMMENT_ID } = process.env
 
 const MyOctokit = Octokit.plugin(paginateRest, createOrUpdateTextFile).defaults({
@@ -54,6 +54,7 @@ async function run() {
   const content = stripHtmlComments(body)
   const commentTags = extractTagsFromComment(body)
   const title = extractTitleFromComment(body) || content.substring(0, 20)
+  const description = extractDescriptionFromComment(body)
 
   const noteMeta: Note = {
     tags: commentTags,
@@ -63,7 +64,7 @@ async function run() {
     author: OWNER,
     pubDatetime: created_at,
     modDatetime: updated_at || null,
-    description: ""
+    description,
   }
 
   const frontMatter = `---\n${yaml.stringify(noteMeta)}---\n${content}`
@@ -83,4 +84,3 @@ async function run() {
 
   console.log(frontMatter)
 }
-

--- a/actions/src/utils.ts
+++ b/actions/src/utils.ts
@@ -110,6 +110,27 @@ export function extractTitleFromComment(commentBody?: string) {
 }
 
 /**
+ * 从github issue评论中拉取描述
+ * 描述语法：<!-- description: This is description -->
+ * @param commentBody
+ * @returns
+ */
+export function extractDescriptionFromComment(commentBody?: string) {
+  if (!commentBody) {
+    return ''
+  }
+
+  // 匹配 <!-- description: ... -->
+  const regex = /<!--\s*description:\s*([\s\S]*?)-->/i
+  const match = commentBody.match(regex)
+  if (!match) {
+    return ''
+  }
+
+  return match[1].trim()
+}
+
+/**
  * 剔除HTML注释
  * @param markdown
  * @returns


### PR DESCRIPTION
## Summary
- Add AGENTS.md contributor guidelines for this repository.
- Parse `description` metadata from Note issue comments into generated blog frontmatter.

## Validation
- `npm run build:actions`
- `npm run build:blog`
